### PR TITLE
Add #{items := list()} type for encode/decode

### DIFF
--- a/src/aeserialization.erl
+++ b/src/aeserialization.erl
@@ -28,12 +28,14 @@
               | 'binary'
               | 'id'     %% As defined in aec_id.erl
               | [type()] %% Length one in the type. This means a list of any length.
+              | #{items := [{field_name(), type()}]}
               | tuple(). %% Any arity, containing type(). This means a static size array.
 
 -type encodable_term() :: non_neg_integer()
                         | binary()
                         | boolean()
                         | [encodable_term()] %% Of any length
+			| #{atom() => encodable_term()}
                         | tuple()  %% Any arity, containing encodable_term().
                         | aeser_id:id().
 
@@ -101,6 +103,12 @@ decode_fields(Template, Values) ->
 
 encode_field([Type], L) when is_list(L) ->
     [encode_field(Type, X) || X <- L];
+encode_field(#{items := Items}, Map) ->
+    lists:map(
+      fun({K, Type}) ->
+              V = maps:get(K, Map),
+              encode_field(Type, V)
+      end, Items);
 encode_field(Type, T) when tuple_size(Type) =:= tuple_size(T) ->
     Zipped = lists:zip(tuple_to_list(Type), tuple_to_list(T)),
     [encode_field(X, Y) || {X, Y} <- Zipped];
@@ -117,6 +125,12 @@ encode_field(Type, Val) -> error({illegal, Type, Val}).
 
 decode_field([Type], List) when is_list(List) ->
     [decode_field(Type, X) || X <- List];
+decode_field(#{items := Items}, List) when length(List) =:= length(Items) ->
+    Zipped = lists:zip(Items, List),
+    lists:foldl(
+      fun({{K, Type}, V}, Map) ->
+              Map#{ K => decode_field(Type, V) }
+      end, #{}, Zipped);
 decode_field(Type, List) when length(List) =:= tuple_size(Type) ->
     Zipped = lists:zip(tuple_to_list(Type), List),
     list_to_tuple([decode_field(X, Y) || {X, Y} <- Zipped]);

--- a/src/aeserialization.erl
+++ b/src/aeserialization.erl
@@ -129,6 +129,7 @@ decode_field(#{items := Items}, List) when length(List) =:= length(Items) ->
     Zipped = lists:zip(Items, List),
     lists:foldl(
       fun({{K, Type}, V}, Map) ->
+              maps:is_key(K, Map) andalso error(badarg, duplicate_field),
               Map#{ K => decode_field(Type, V) }
       end, #{}, Zipped);
 decode_field(Type, List) when length(List) =:= tuple_size(Type) ->

--- a/src/aeserialization.erl
+++ b/src/aeserialization.erl
@@ -28,7 +28,7 @@
               | 'binary'
               | 'id'     %% As defined in aec_id.erl
               | [type()] %% Length one in the type. This means a list of any length.
-              | #{items := [{field_name(), type()}]}
+              | #{items := [{field_name(), type()}]} %% Record with named fields represented as a map. Encoded as a list in the given order.
               | tuple(). %% Any arity, containing type(). This means a static size array.
 
 -type encodable_term() :: non_neg_integer()


### PR DESCRIPTION
Add support for decoding sub-structures.

Example:
```erlang
serialization_template(ping, ?PING_VSN) ->
    [ {versions, [#{items => [ {protocol, binary}
                             , {vsns, [int]}]
                   }]
      }
    , {port, int}
...
```

Previously, the template supported only `[type()]`, denoting a list where all elements are of the same type. This made it tricky to extend the list pattern. Also, complex subtypes aren't necessarily that descriptive:

```erlang
capabilities_template(<<"chain_poi">>, ?PING_VSN) ->
    [{chain_poi, #{ items => [ {height, int}
                             , {root_hash, binary}
                             , {genesis, binary}
                             , {top, binary}
                             , {poi, binary} ]}
     }].
```

The serialization would look like this:

```erlang
(aeternity@localhost)1> Cs = [{chain_poi,[#{height => 1000, root_hash => <<"rx">>, genesis => <<"gx">>, top => <<"tx">>, poi => <<"px">>}]}].
[{chain_poi,[#{genesis => <<"gx">>,height => 1000,poi => <<"px">>,
               root_hash => <<"rx">>,top => <<"tx">>}]}]
(aeternity@localhost)2> aec_peer_messages:serialize_capabilities(2,Cs).
<<221,220,137,99,104,97,105,110,95,112,111,105,145,208,
  207,130,3,232,130,114,120,130,103,120,130,116,120,130,
  112,...>>
(aeternity@localhost)3> aeser_rlp:decode(v(2)).
[[<<"chain_poi">>,
  <<208,207,130,3,232,130,114,120,130,103,120,130,116,120,
    130,112,120>>]]
(aeternity@localhost)4> [[_,Sub]] = v(3).
[[<<"chain_poi">>,
  <<208,207,130,3,232,130,114,120,130,103,120,130,116,120,
    130,112,120>>]]
(aeternity@localhost)5> aeser_rlp:decode(Sub).
[[<<3,232>>,<<"rx">>,<<"gx">>,<<"tx">>,<<"px">>]]
```