### PR TITLE
Pin encoding into aeser

### DIFF
--- a/src/aeser_api_encoder.erl
+++ b/src/aeser_api_encoder.erl
@@ -13,8 +13,7 @@
          encode_parent_pin_payload/1,
          decode_parent_pin_payload/1,
          encode_child_pin_payload/1,
-         decode_child_pin_payload/1,
-         is_pin/1]).
+         decode_child_pin_payload/1]).
 
 -export_type([encoded/0]).
 
@@ -340,9 +339,3 @@ decode_child_pin_payload(<<"pin", TxHash/binary>>) ->
     {ok, TxHash};
 decode_child_pin_payload(BadTxHash) ->
     {error, {bad_child_pin_payload, BadTxHash}}.
-
-is_pin(Pin) ->
-    case decode_child_pin_payload(Pin) of
-        {error,_} -> false;
-        _ -> true
-    end.

--- a/src/aeser_api_encoder.erl
+++ b/src/aeser_api_encoder.erl
@@ -9,7 +9,12 @@
 -export([encode/2,
          decode/1,
          safe_decode/2,
-         byte_size_for_type/1]).
+         byte_size_for_type/1,
+         encode_parent_pin_payload/1,
+         decode_parent_pin_payload/1,
+         encode_child_pin_payload/1,
+         decode_child_pin_payload/1,
+         is_pin/1]).
 
 -export_type([encoded/0]).
 
@@ -304,3 +309,40 @@ binary_to_base64(Bin) ->
 
 base64_to_binary(Bin) when is_binary(Bin) ->
     base64:decode(Bin).
+
+%%%=============================================================================
+%%% Pinning
+%%%=============================================================================
+
+-spec encode_parent_pin_payload(#{epoch => integer(), height => integer(), block_hash => binary()}) -> binary().
+encode_parent_pin_payload(#{epoch := Epoch, height := Height, block_hash := BlockHash}) ->
+    EpochHex = list_to_binary(erlang:integer_to_list(Epoch, 16)),
+    HeightHex = list_to_binary(erlang:integer_to_list(Height, 16)),
+    EncBlockHash = aeser_api_encoder:encode(key_block_hash, BlockHash),
+    <<EpochHex/binary, ":", HeightHex/binary, " ", EncBlockHash/binary>>.
+
+%-spec decode_parent_pin_payload(binary()) -> #{epoch => integer(), height => integer(), block_hash => binary()}.
+decode_parent_pin_payload(Binary) ->
+    try
+        [HexEpoch, HexHeight, EncBlockHash] = binary:split(Binary, [<<":">>, <<" ">>], [global]),
+        Epoch = erlang:list_to_integer(binary_to_list(HexEpoch), 16),
+        Height = erlang:list_to_integer(binary_to_list(HexHeight), 16),
+        {ok, BlockHash} = aeser_api_encoder:safe_decode(key_block_hash, EncBlockHash),
+        {ok, #{epoch => Epoch, height => Height, block_hash => BlockHash}}
+    catch
+        _ -> {error, {bad_parent_pin_payload, Binary}}
+    end.
+
+encode_child_pin_payload(TxHash) ->
+    <<"pin", TxHash/binary>>.
+
+decode_child_pin_payload(<<"pin", TxHash/binary>>) ->
+    {ok, TxHash};
+decode_child_pin_payload(BadTxHash) ->
+    {error, {bad_child_pin_payload, BadTxHash}}.
+
+is_pin(Pin) ->
+    case decode_child_pin_payload(Pin) of
+        {error,_} -> false;
+        _ -> true
+    end.

--- a/src/aeser_hc.erl
+++ b/src/aeser_hc.erl
@@ -45,7 +45,7 @@ decode_parent_pin_payload(Binary) ->
         {ok, BlockHash} = aeser_api_encoder:safe_decode(key_block_hash, EncBlockHash),
         {ok, #{epoch => Epoch, height => Height, block_hash => BlockHash}}
     catch
-        _ -> {error, {bad_parent_pin_payload, Binary}}
+        _:_ -> {error, {bad_parent_pin_payload, Binary}}
     end.
 
 %%=============================================================================

--- a/src/aeser_hc.erl
+++ b/src/aeser_hc.erl
@@ -35,7 +35,8 @@ encode_parent_pin_payload(#{epoch := Epoch, height := Height, block_hash := Bloc
 %% Decode a bionary payload to an Epoch info map when fetching pinning info
 %% from the parent chain
 %% =============================================================================
--spec decode_parent_pin_payload(binary()) -> #{epoch => integer(), height => integer(), block_hash => binary()}.
+-spec decode_parent_pin_payload(binary()) ->
+    {ok, #{epoch => integer(), height => integer(), block_hash => term()}} | {error, term()}.
 decode_parent_pin_payload(Binary) ->
     try
         [HexEpoch, HexHeight, EncBlockHash] = binary:split(Binary, [<<":">>, <<" ">>], [global]),

--- a/src/aeser_hc.erl
+++ b/src/aeser_hc.erl
@@ -1,7 +1,7 @@
 %%%-----------------------------------------------------------------------------
 %%% @copyright (C) 2024, Aeternity Anstalt
 %%% @doc
-%%% Module for various Hypoerchain-related encoding tasks
+%%% Module for various Hyperchain-related encoding tasks
 %%% @end
 %%%-----------------------------------------------------------------------------
 
@@ -53,12 +53,14 @@ decode_parent_pin_payload(Binary) ->
 %% easily findable when notarized (in a spend tx to the leader of the last
 %% epoch block) to the hyper chain.
 %%=============================================================================
+-spec encode_child_pin_payload(binary()) -> binary().
 encode_child_pin_payload(TxHash) ->
     <<"pin", TxHash/binary>>.
 
 %%=============================================================================
 %% Decode a pinning transacation notarization payload
 %% =============================================================================
+-spec decode_child_pin_payload(binary()) -> {ok, binary()} | {error, term()}.
 decode_child_pin_payload(<<"pin", TxHash/binary>>) ->
     {ok, TxHash};
 decode_child_pin_payload(BadTxHash) ->

--- a/src/aeser_hc.erl
+++ b/src/aeser_hc.erl
@@ -1,0 +1,64 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2024, Aeternity Anstalt
+%%% @doc
+%%% Module for various Hypoerchain-related encoding tasks
+%%% @end
+%%%-----------------------------------------------------------------------------
+
+-module(aeser_hc).
+
+-export([encode_parent_pin_payload/1,
+         decode_parent_pin_payload/1,
+         encode_child_pin_payload/1,
+         decode_child_pin_payload/1]).
+
+%%%=============================================================================
+%%% Global Definitions
+%%%=============================================================================
+
+%%%=============================================================================
+%%% Pinning
+%%%=============================================================================
+
+%%=============================================================================
+%% Encode an Epoch info map to a <80 bytes binary to use in payload when pinning
+%% Hyperchain state to the parent chain
+%% =============================================================================
+-spec encode_parent_pin_payload(#{epoch => integer(), height => integer(), block_hash => binary()}) -> binary().
+encode_parent_pin_payload(#{epoch := Epoch, height := Height, block_hash := BlockHash}) ->
+    EpochHex = list_to_binary(erlang:integer_to_list(Epoch, 16)),
+    HeightHex = list_to_binary(erlang:integer_to_list(Height, 16)),
+    EncBlockHash = aeser_api_encoder:encode(key_block_hash, BlockHash),
+    <<EpochHex/binary, ":", HeightHex/binary, " ", EncBlockHash/binary>>.
+
+%%=============================================================================
+%% Decode a bionary payload to an Epoch info map when fetching pinning info
+%% from the parent chain
+%% =============================================================================
+-spec decode_parent_pin_payload(binary()) -> #{epoch => integer(), height => integer(), block_hash => binary()}.
+decode_parent_pin_payload(Binary) ->
+    try
+        [HexEpoch, HexHeight, EncBlockHash] = binary:split(Binary, [<<":">>, <<" ">>], [global]),
+        Epoch = erlang:list_to_integer(binary_to_list(HexEpoch), 16),
+        Height = erlang:list_to_integer(binary_to_list(HexHeight), 16),
+        {ok, BlockHash} = aeser_api_encoder:safe_decode(key_block_hash, EncBlockHash),
+        {ok, #{epoch => Epoch, height => Height, block_hash => BlockHash}}
+    catch
+        _ -> {error, {bad_parent_pin_payload, Binary}}
+    end.
+
+%%=============================================================================
+%% Encode the transaction hash returned when pinning to the parent chain to be
+%% easily findable when notarized (in a spend tx to the leader of the last
+%% epoch block) to the hyper chain.
+%%=============================================================================
+encode_child_pin_payload(TxHash) ->
+    <<"pin", TxHash/binary>>.
+
+%%=============================================================================
+%% Decode a pinning transacation notarization payload
+%% =============================================================================
+decode_child_pin_payload(<<"pin", TxHash/binary>>) ->
+    {ok, TxHash};
+decode_child_pin_payload(BadTxHash) ->
+    {error, {bad_child_pin_payload, BadTxHash}}.


### PR DESCRIPTION
Moved the pin encoding/decoding methods from core to serialization. A follow-up PR will be done post merge for the corresponding refactoring in `aeternity/aeternity`

This pull request is supported by the Æternity Foundation.